### PR TITLE
:sparkles: 2024.06.28. LIS

### DIFF
--- a/jerry/BOJ_1365_꼬인전깃줄.py
+++ b/jerry/BOJ_1365_꼬인전깃줄.py
@@ -1,0 +1,29 @@
+import sys
+input = sys.stdin.readline
+
+N = int(input())
+li = list(map(int, input().split()))
+
+lis = []
+lis.append(li[0])
+
+def lower_bound(target):
+    left = 0
+    right = len(lis)-1
+    while left < right:
+        mid = (left + right) // 2
+        if lis[mid] > target:
+            right = mid
+        else :
+            left = mid + 1
+    return left
+
+for i in range(1,N):
+    if lis[-1] < li[i]:
+        # 들어갈 수 있는 경우에는
+        lis.append(li[i])
+    else:
+        # 들어갈 수 없는 경우에는 이분탐색으로 위치 찾아서 넣음
+        jdx = lower_bound(li[i])
+        lis[jdx] = li[i]
+print(N - len(lis))


### PR DESCRIPTION
# Intuition
이 문제는 양쪽 전봇대가 오름차순으로 정렬되어 있다고 가정하고 시작하므로, 주어진 수열에서 최장 증가 부분 수열의 길이를 구해서 N에서 빼주면 그게 최소로 잘라내는 개수일 것이다.
# Algorithm
LIS를 구성하기 위해서는 다음 로직을 반복한다.
1. 수열을 순회하면서 LIS[-1]보다 numbers[i]가 더 크다면 LIS.append(numbers[i])
2. 만약 LIS[-1] >= numbers[i] 라면 들어갈 수 있는 위치를 이진탐색으로 찾아서 넣음
-> 위 과정을 반복하면 정확한 최장 증가 부분수열을 구할 순 없지만, 최장 증가 부분수열의 길이는 찾을 수 있다.
*** 최장 증가 부분수열을 정확히 구하는 알고리즘은 DP를 이용해야 한다.
# Complexity Analysis
- time complexity : O(N*logN)
- space complexity : O(N)