### PR TITLE
:sparkles: 2024.06.28. prefix_sum + binary_search

### DIFF
--- a/jerry/BOJ_2143_두배열의합.py
+++ b/jerry/BOJ_2143_두배열의합.py
@@ -1,0 +1,53 @@
+import sys
+input = sys.stdin.readline
+from collections import defaultdict
+
+T = int(input())
+N = int(input())
+arr = list(map(int, input().split()))
+M = int(input())
+brr = list(map(int, input().split()))
+
+"""
+단순하게 하면 O(N^2 * M^2) : 모든 경우의 수 브루트포스
+각각 N*logN으로 줄일 순 없을까? -> 누적합 ; 가능할 듯
+"""
+
+psa = [0]
+for i in range(0,N):
+    psa.append(psa[-1] + arr[i])
+psb = [0]
+for i in range(0, M):
+    psb.append(psb[-1] + brr[i])
+
+a_dict = defaultdict(int)
+b_dict = defaultdict(int)
+
+for i in range(1, N+1): # subarray 길이
+    for j in range(0, N - i + 1):
+        ps = psa[j+i] - psa[j]
+        a_dict[ps] = a_dict[ps] + 1
+for i in range(1, M+1):
+    for j in range(0, M - i + 1):
+        ps = psb[j+i] - psb[j]
+        b_dict[ps] = b_dict[ps] + 1
+a_keys = sorted(a_dict.keys())
+b_keys = sorted(b_dict.keys())
+
+def bs(v):
+    left = 0
+    right = len(b_keys) - 1
+    while left <= right:
+        mid = (left + right) // 2
+        if b_keys[mid] + v == T:
+            return b_dict[b_keys[mid]]
+        elif b_keys[mid] + v < T:
+            left = mid + 1
+        else :
+            right = mid - 1
+    return 0
+
+ans = 0
+for i in a_keys:
+    ans += (bs(i) * a_dict[i])
+print(ans)


### PR DESCRIPTION
# Intuition
각각 부분수열의 합의 경우의 수를 기록해두려면 가장 단순하게는 길이결정loop*시작인덱스loop*범위반복loop 까지 저장해둘 수 있다. 하지만 이는 O(N^3 + M^3)이므로 이미 시간이 초과된다. 이를 개선하려면 3차원 루프 연산을 하지 않아도 되도록 사전에 누적합을 구해두면 된다.
누적합을 구해둔 채로 경우의 수를 기록하는 연산은 길이결정loop*시작인덱스loop까지 해서 O(N^2 + M^2)이다. 이렇게 구한 경우의 수를 dictionary에 저장해둔다. 그리고 첫 번째 경우의 수를 순회하면서 두 번째 배열의 경우의 수 중에서 더한게 T가 될 수 있는 경우를 이분탐색으로 찾아낸다. 이렇게 하면 총 시간복잡도를 O(N^2 + M^2 + N^2*logM^2)으로 풀어낼 수 있다.
*** 만약 여기서 dictionary를 쓰지 않고 li.count() 함수를 사용하고자 하면 경우의 수의 합이 T인 경우를 찾는 로직에서 M이 더 곱해져야 해서 시간초과가 뜬다. (내가 그랬다.)

# Algorithm
1. 각 배열의 누적합을 구한다.
2. 누적합을 이용하여 부분수열의 합의 경우의 수를 미리 구해서, 각 경우의 수의 개수를 dictionary에 저장해둔다.
3. 첫 번째 배열의 부분수열의 합의 경우의 수를 순회하면서, 이분탐색을 이용하여 두 배열의 부분수열의 합이 T인 경우의 수를 카운트한다.

# Complexity Analysis
- time complexity : O(N^2 + M^2 + N^2*logM^2)
- space complexity : O(N^2 + M^2)